### PR TITLE
:sparkles: Enable CMAKE_EXPERIMENTAL_EXPORT_PACKAGE_DEPENDENCIES

### DIFF
--- a/cmake/modules_toolchain.cmake
+++ b/cmake/modules_toolchain.cmake
@@ -12,51 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Enable C++20/23 modules support
-# Skip during try_compile (compiler detection) to avoid __CMAKE::CXX23 errors
+# Enable C++20 modules support
+# This toolchain automatically enables C++ modules support
+# No user action required - just include this via Conan
+
+# Skip during try_compile to avoid errors
 if(NOT CMAKE_CURRENT_SOURCE_DIR MATCHES "CMakeScratch")
-  block()
-    # Version requirements:
-    # C++20 modules: GCC 14+, Clang 18+, MSVC 19.29+
-    # import std: GCC 15+, Clang 18.1.2+, MSVC 19.40+
-    set(_MODULES_SUPPORTED OFF)
-    set(_IMPORT_STD_SUPPORTED OFF)
+  # Enable C++20 modules scanning
+  set(CMAKE_CXX_SCAN_FOR_MODULES ON)
 
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0")
-        set(_MODULES_SUPPORTED ON)
-      endif()
-      if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "15.0")
-        set(_IMPORT_STD_SUPPORTED ON)
-      endif()
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
-           CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-      if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "18.0")
-        set(_MODULES_SUPPORTED ON)
-      endif()
-      if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "18.1.2")
-        set(_IMPORT_STD_SUPPORTED ON)
-      endif()
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-      if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.29")
-        set(_MODULES_SUPPORTED ON)
-      endif()
-      if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.40")
-        set(_IMPORT_STD_SUPPORTED ON)
-      endif()
-    endif()
+  # Enable experimental package dependency export for modules
+  set(CMAKE_EXPERIMENTAL_EXPORT_PACKAGE_DEPENDENCIES "1942b4fa-b2c5-4546-9385-83f254070067")
 
-    if(_MODULES_SUPPORTED)
-      set(CMAKE_CXX_MODULE_STD ON PARENT_SCOPE)
-      set(CMAKE_CXX_SCAN_FOR_MODULES ON PARENT_SCOPE)
-    else()
-      message(STATUS "C++20 modules disabled: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} does not support it")
-    endif()
-
-    if(_IMPORT_STD_SUPPORTED)
-      set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "d0edc3af-4c50-42ea-a356-e2862fe7a444" PARENT_SCOPE)
-    else()
-      message(STATUS "import std disabled: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} does not support it")
-    endif()
-  endblock()
+  # Print status message after project() is called
+  function(_libhal_modules_status)
+    message(STATUS "C++20 modules support enabled")
+  endfunction()
+  cmake_language(DEFER CALL _libhal_modules_status)
 endif()

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@
 
 from conan import ConanFile
 from conan.tools.files import copy
-import os
+from pathlib import Path
 
 
 required_conan_version = ">=2.2.0"
@@ -22,7 +22,7 @@ required_conan_version = ">=2.2.0"
 
 class cmake_modules_toolchain_conan(ConanFile):
     name = "cmake-modules-toolchain"
-    version = "1.0.2"
+    version = "1.0.3"
     license = "Apache-2.0"
     homepage = "https://github.com/libhal/cmake-modules-toolchain"
     description = "CMake toolchain for enabling C++ modules and import std"
@@ -38,15 +38,16 @@ class cmake_modules_toolchain_conan(ConanFile):
         self.info.clear()
 
     def package(self):
-        copy(self, "LICENSE", dst=os.path.join(
-            self.package_folder, "licenses"), src=self.source_folder)
-        copy(self, "cmake/*.cmake", src=self.source_folder,
+        copy(self, "LICENSE",
+             dst=Path(self.package_folder) / "licenses",
+             src=self.source_folder)
+        copy(self, "cmake/*.cmake",
+             src=self.source_folder,
              dst=self.package_folder)
 
     def package_info(self):
-        toolchain_path = os.path.join(
-            self.package_folder, "cmake/modules_toolchain.cmake")
-        self.conf_info.append(
-            "tools.cmake.cmaketoolchain:user_toolchain",
-            toolchain_path)
+        PACKAGE_DIR = Path(self.package_folder)
+        TOOLCHAIN_PATH = str(PACKAGE_DIR / "cmake" / "modules_toolchain.cmake")
+        self.conf_info.append("tools.cmake.cmaketoolchain:user_toolchain",
+                              TOOLCHAIN_PATH)
         self.conf_info.define("tools.cmake.cmaketoolchain:generator", "Ninja")


### PR DESCRIPTION
This change also removes much of the conditional code that was actually completely broken previously. The previous code could not work because compiler details are not available at the time the toolchains are injected into the build.

Import std support comes with some annoyances that make it problematic if used with a compiler that doesn't support it, or even those that do.

For now, this package will simply enable the safe flags that cause no problems even if modules are not used.

Version upgrade to 1.0.3